### PR TITLE
Rendering native language dropdown in registration form.

### DIFF
--- a/src/components/auth/RegisterForm/RegisterForm.js
+++ b/src/components/auth/RegisterForm/RegisterForm.js
@@ -1,6 +1,7 @@
-import React, { useContext, useState } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 
 import { UserContext } from '../../user/UserProvider';
+import { LanguageContext } from '../../language/LanguageProvider';
 import Form from '../../form/Form';
 import { useFormConfig, useIsFormValid } from '../../form/formCustomHooks';
 import registerFormConfig from './registerFormConfig';
@@ -8,10 +9,25 @@ import registerFormConfig from './registerFormConfig';
 const RegisterForm = props => {
   const [ didRegisterFail, setDidRegisterFail ] = useState(false);
 
-  const [ formConfig, handleFormChange ] = useFormConfig(registerFormConfig);
+  const [ formConfig, handleFormChange, setFormConfig ] = useFormConfig(registerFormConfig);
   const isFormValid = useIsFormValid(formConfig);
 
   const { getUserByEmail, saveUser } = useContext(UserContext);
+  const { getLanguages, languages } = useContext(LanguageContext);
+
+  useEffect(() => {
+    getLanguages();
+  }, []);
+
+  useEffect(() => {
+    if(languages.length && !formConfig.nativeLanguageId.items.length) {
+      const updatedFormConfig = { ...formConfig };
+      const updatedFormElement = { ...updatedFormConfig.nativeLanguageId };
+      updatedFormElement.items = languages.map(l => ({ value: l.id, displayName: l.name }));
+      updatedFormConfig.nativeLanguageId = updatedFormElement;
+      setFormConfig(updatedFormConfig);
+    }
+  }, [ languages, formConfig, setFormConfig ]);
 
   const handleChange = changeData => {
     setDidRegisterFail(false);
@@ -28,7 +44,8 @@ const RegisterForm = props => {
         firstName: formConfig.firstName.value,
         lastName: formConfig.lastName.value,
         email: formConfig.email.value,
-        password: formConfig.password.value
+        password: formConfig.password.value,
+        nativeLanguageId: parseInt(formConfig.nativeLanguageId.value)
       };
 
       const newUser = await saveUser(newUserData);

--- a/src/components/auth/RegisterForm/registerFormConfig.js
+++ b/src/components/auth/RegisterForm/registerFormConfig.js
@@ -73,5 +73,20 @@ export default {
     },
     isTouched: false,
     isValid: false
+  },
+
+  nativeLanguageId: {
+    inputType: 'select',
+    elementConfig: {
+      name: 'nativeLanguageId',
+      placeholder: 'Select your native language'
+    },
+    value: '',
+    items: [],
+    validation: {
+      isRequired: true
+    },
+    isTouched: false,
+    isValid: false
   }
 };

--- a/src/components/auth/UnauthorizedUserLandingPage/UnauthorizedUserLandingPage.js
+++ b/src/components/auth/UnauthorizedUserLandingPage/UnauthorizedUserLandingPage.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { LanguageProvider } from '../../language/LanguageProvider';
 
 import LoginForm from '../LoginForm/LoginForm';
 import RegisterForm from '../RegisterForm/RegisterForm';
@@ -6,7 +7,9 @@ import RegisterForm from '../RegisterForm/RegisterForm';
 const UnauthorizedUserLandingPage = props => (
   <div>
     <LoginForm {...props} />
-    <RegisterForm {...props} />
+    <LanguageProvider>
+      <RegisterForm {...props} />
+    </LanguageProvider>
   </div>
 );
 

--- a/src/components/form/Form.js
+++ b/src/components/form/Form.js
@@ -41,11 +41,12 @@ const Form = props => {
   return (
     <form className="form" onSubmit={handleSubmit}>
       { formConfigArray.map(inputConfig => {
-        const { name, inputType, elementConfig, value, isTouched, isValid } = inputConfig;
+        const { name, inputType, elementConfig, value, isTouched, isValid, items } = inputConfig;
         return <Input key={name}
           inputType={inputType}
           elementConfig={elementConfig}
           value={value}
+          items={items}
           onChange={handleChange}
           isTouched={isTouched}
           isValid={isValid} />;

--- a/src/components/form/formCustomHooks.js
+++ b/src/components/form/formCustomHooks.js
@@ -10,7 +10,7 @@ export const useIsFormValid = formConfig => {
     if(_isFormValid !== isFormValid) {
       setIsFormValid(_isFormValid);
     }
-  }, [ formConfig ]);
+  }, [ formConfig, isFormValid ]);
 
   return isFormValid;
 };
@@ -33,5 +33,5 @@ export const useFormConfig = initialFormConfig => {
     setFormConfig(updatedFormConfig);
   };
 
-  return [ formConfig, handleChange ];
+  return [ formConfig, handleChange, setFormConfig ];
 };

--- a/src/components/form/input/Input.js
+++ b/src/components/form/input/Input.js
@@ -6,7 +6,7 @@ const Input = props => {
   const { inputType, isTouched, isValid, label, elementConfig, value, onChange, items } = props;
 
   let inputElement;
-  switch(props.inputType) {
+  switch(inputType) {
     case 'input':
       inputElement = <input {...elementConfig}
         value={value}
@@ -19,6 +19,8 @@ const Input = props => {
       break;
     case 'select':
       inputElement = <Select {...elementConfig}
+        value={value}
+        onChange={onChange}
         items={items} />;
       break;
     default:

--- a/src/components/form/select/Select.js
+++ b/src/components/form/select/Select.js
@@ -7,7 +7,7 @@ const Select = props => {
   return (
     <select {...props}>
       <option value="" disabled>{placeholder}</option>
-      { items.map(i => <option value={i.value}>{i.displayName}</option>) }
+      { items.map(i => <option key={i.value} value={i.value}>{i.displayName}</option>) }
     </select>
   );
 };

--- a/src/components/language/LanguageProvider.js
+++ b/src/components/language/LanguageProvider.js
@@ -1,0 +1,21 @@
+import React, { createContext, useState } from 'react';
+
+export const LanguageContext = createContext();
+
+export const LanguageProvider = props => {
+  const [ languages, setLanguages ] = useState([]);
+  
+  const getLanguages = async () => {
+    const res = await fetch('http://localhost:8088/languages');
+    const _languages = await res.json();
+    setLanguages(_languages);
+  };
+
+  return (
+    <LanguageContext.Provider value={{
+      languages, getLanguages
+    }}>
+      {props.children}
+    </LanguageContext.Provider>
+  );
+};


### PR DESCRIPTION
1. Verify that the Registration form now renders a `<select>` allowing the user to pick their native language when registering a new account.
1. Verify that the user must select a value on this input to be able to create an account.