### PR TITLE
start time should be set to null if the video changes

### DIFF
--- a/src/components/transcriptionRequestWorkshop/TranscriptionRequestWorkshop.js
+++ b/src/components/transcriptionRequestWorkshop/TranscriptionRequestWorkshop.js
@@ -15,6 +15,11 @@ const TranscriptionRequestWorkshop = () => {
     }
   };
 
+  const handleYouTubeSearchBarChange = videoId => {
+    setVideoId(videoId);
+    setStartTime(null);
+  };
+
   const handleTranscriptionRequestControlClick = () => {
     const timeClicked = player.getCurrentTime();
 
@@ -36,7 +41,7 @@ const TranscriptionRequestWorkshop = () => {
 
   return (
     <section className="workshop">
-      <YouTubeSearchBar value={videoId} onChange={setVideoId} />
+      <YouTubeSearchBar value={videoId} onChange={handleYouTubeSearchBarChange} />
       <YouTube videoId={videoId} onStateChange={handleYouTubeStateChange} />
 
       <TranscriptionRequestControl isRequesting={!!startTime} onClick={handleTranscriptionRequestControlClick} />


### PR DESCRIPTION
1. Verify that if you start a transcription request while watching a youtube video, and then change to a different video, that the start time will be set back to null for your transcription request (cause effectively that is considered as cancelling your request).