### PR TITLE
Je transcription activation wizard confirm transcription request

### DIFF
--- a/src/components/ApplicationViews.js
+++ b/src/components/ApplicationViews.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Route, Redirect } from 'react-router-dom';
+import { LanguageProvider } from './language/LanguageProvider';
 import { TranscriptionRequestProvider } from './transcriptionRequest/TranscriptionRequestProvider';
 import TranscriptionRequestWorkshop from './transcriptionRequestWorkshop/TranscriptionRequestWorkshop';
 
@@ -12,7 +13,9 @@ const ApplicationViews = props => (
     }} />
 
     <TranscriptionRequestProvider>
-      <Route path="/workshop" component={TranscriptionRequestWorkshop} />
+      <LanguageProvider>
+        <Route path="/workshop" component={TranscriptionRequestWorkshop} />
+      </LanguageProvider>
     </TranscriptionRequestProvider>
   </>
 );

--- a/src/components/auth/RegisterForm/RegisterForm.js
+++ b/src/components/auth/RegisterForm/RegisterForm.js
@@ -9,7 +9,7 @@ import registerFormConfig from './registerFormConfig';
 const RegisterForm = props => {
   const [ didRegisterFail, setDidRegisterFail ] = useState(false);
 
-  const [ formConfig, handleFormChange, setFormConfig ] = useFormConfig(registerFormConfig);
+  const [ formConfig, handleFormChange, updateFormConfig ] = useFormConfig(registerFormConfig);
   const isFormValid = useIsFormValid(formConfig);
 
   const { getUserByEmail, saveUser } = useContext(UserContext);
@@ -21,13 +21,10 @@ const RegisterForm = props => {
 
   useEffect(() => {
     if(languages.length && !formConfig.nativeLanguageId.items.length) {
-      const updatedFormConfig = { ...formConfig };
-      const updatedFormElement = { ...updatedFormConfig.nativeLanguageId };
-      updatedFormElement.items = languages.map(l => ({ value: l.id, displayName: l.name }));
-      updatedFormConfig.nativeLanguageId = updatedFormElement;
-      setFormConfig(updatedFormConfig);
+      const items = languages.map(l => ({ value: l.id, displayName: l.name }));
+      updateFormConfig('nativeLanguageId', items, 'items');
     }
-  }, [ languages, formConfig, setFormConfig ]);
+  }, [ languages, formConfig, updateFormConfig ]);
 
   const handleChange = changeData => {
     setDidRegisterFail(false);

--- a/src/components/form/Form.js
+++ b/src/components/form/Form.js
@@ -1,10 +1,24 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 
 import Input from './input/Input';
 
 const Form = props => {
   const { formConfig, onChange, onSubmit } = props;
+
+  // for forms that can be pre-populated, we need to first manually trigger validation... this will run validation on any untouched field in a form when its data changes (an untouched change means the change is not coming from the user, but from some controlled data initially being set e.g. inital values for a field being populated by values of an object loaded from database)
+  useEffect(() => {
+    const validiationChanges = Object.keys(formConfig)
+      .filter(fieldName => !formConfig[fieldName].isTouched && formConfig[fieldName].isValid !== validate(fieldName, formConfig[fieldName].value))
+      .map(fieldName => ({
+        name: fieldName,
+        value: formConfig[fieldName].value,
+        isValid: validate(fieldName, formConfig[fieldName].value)
+      }));
+    if(validiationChanges.length) {
+      validiationChanges.forEach(onChange);
+    }
+  }, [ formConfig ]);
 
   const handleSubmit = e => {
     e.preventDefault();

--- a/src/components/form/formCustomHooks.js
+++ b/src/components/form/formCustomHooks.js
@@ -34,11 +34,13 @@ export const useFormConfig = initialFormConfig => {
   };
 
   const updateFormConfig = (formFieldName, newValue, propertyToUpdate = 'value') => {
-    const updatedFormConfig = { ...formConfig };
-    const updatedFormElement = { ...updatedFormConfig[formFieldName] };
-    updatedFormElement[propertyToUpdate] = newValue;
-    updatedFormConfig[formFieldName] = updatedFormElement;
-    setFormConfig(updatedFormConfig);
+    setFormConfig(prevFormConfig => {
+      const updatedFormConfig = { ...prevFormConfig };
+      const updatedFormElement = { ...updatedFormConfig[formFieldName] };
+      updatedFormElement[propertyToUpdate] = newValue;
+      updatedFormConfig[formFieldName] = updatedFormElement
+      return updatedFormConfig;
+    });
   };
 
   return [ formConfig, handleChange, updateFormConfig ];

--- a/src/components/form/formCustomHooks.js
+++ b/src/components/form/formCustomHooks.js
@@ -43,5 +43,9 @@ export const useFormConfig = initialFormConfig => {
     });
   };
 
-  return [ formConfig, handleChange, updateFormConfig ];
+  const resetFormConfig = () => {
+    setFormConfig({ ...initialFormConfig });
+  };
+
+  return [ formConfig, handleChange, updateFormConfig, resetFormConfig ];
 };

--- a/src/components/form/formCustomHooks.js
+++ b/src/components/form/formCustomHooks.js
@@ -33,5 +33,13 @@ export const useFormConfig = initialFormConfig => {
     setFormConfig(updatedFormConfig);
   };
 
-  return [ formConfig, handleChange, setFormConfig ];
+  const updateFormConfig = (formFieldName, newValue, propertyToUpdate = 'value') => {
+    const updatedFormConfig = { ...formConfig };
+    const updatedFormElement = { ...updatedFormConfig[formFieldName] };
+    updatedFormElement[propertyToUpdate] = newValue;
+    updatedFormConfig[formFieldName] = updatedFormElement;
+    setFormConfig(updatedFormConfig);
+  };
+
+  return [ formConfig, handleChange, updateFormConfig ];
 };

--- a/src/components/transcriptionRequest/TranscriptionRequestActivationWizard/TranscriptionRequestActivationWizard.js
+++ b/src/components/transcriptionRequest/TranscriptionRequestActivationWizard/TranscriptionRequestActivationWizard.js
@@ -2,7 +2,7 @@ import React, { useEffect, useState, useContext } from 'react';
 import PropTypes from 'prop-types';
 
 import { TranscriptionRequestContext } from '../TranscriptionRequestProvider';
-import { LanguageContext, LangugageContext } from '../../language/LanguageProvider';
+import { LanguageContext } from '../../language/LanguageProvider';
 import TranscriptionRequestConfirm from './TranscriptionRequestConfirm/TranscriptionRequestConfirm';
 import transcriptionRequestConfirmFormConfig from './TranscriptionRequestConfirm/transcriptionRequestConfirmConfig';
 import { useFormConfig } from '../../form/formCustomHooks';
@@ -34,6 +34,7 @@ const TranscriptionRequestActivationWizard = props => {
     }
   }, [ transcriptionRequestId ]);
 
+  // populate language dropdown in form with loaded languages data
   useEffect(() => {
     if(languages.length && !transciptionRequestFormConfig.languageId.items.length) {
       const items = languages.map(l => ({ value: l.id, displayName: l.name }));
@@ -41,6 +42,7 @@ const TranscriptionRequestActivationWizard = props => {
     }
   }, [ languages, transciptionRequestFormConfig, updateTranscriptionRequestFormConfig ]);
 
+  // populate startTime and endTime inputs in form with loaded transcriptionRequest data
   useEffect(() => {
     if(transcriptionRequestToConfirm) {
       const { startTime, endTime } = transcriptionRequestToConfirm;

--- a/src/components/transcriptionRequest/TranscriptionRequestActivationWizard/TranscriptionRequestActivationWizard.js
+++ b/src/components/transcriptionRequest/TranscriptionRequestActivationWizard/TranscriptionRequestActivationWizard.js
@@ -20,7 +20,7 @@ const TranscriptionRequestActivationWizard = props => {
 
   const [ currentStep, setCurrentStep ] = useState(0);
   const [ transcriptionRequestToConfirm, setTranscriptionRequestToConfirm ] = useState(null);
-  const [ transciptionRequestFormConfig, handleTranscriptionRequestChange, updateTranscriptionRequestFormConfig ] = useFormConfig(transcriptionRequestConfirmFormConfig);
+  const [ transciptionRequestFormConfig, handleTranscriptionRequestChange, updateTranscriptionRequestFormConfig, resetTranscriptionRequestFormConfig ] = useFormConfig(transcriptionRequestConfirmFormConfig);
   const isTranscriptionRequestFormValid = useIsFormValid(transciptionRequestFormConfig);
 
   useEffect(() => {
@@ -31,6 +31,7 @@ const TranscriptionRequestActivationWizard = props => {
     }
 
     if(transcriptionRequestId) {
+      resetTranscriptionRequestFormConfig();
       getLanguages();
       _getTranscriptionRequestById(transcriptionRequestId);
     }
@@ -73,7 +74,10 @@ const TranscriptionRequestActivationWizard = props => {
       break;
     case WIZARD_STATES.TRANSCRIPTION_CREATION:
       transcriptionRequestActivationWizardBody = (
-        <div>create a transcription lmao</div>
+        <>
+          <div>create a transcription lmao</div>
+          <button onClick={() => setCurrentStep(currentStep => currentStep - 1)}>Back</button>
+        </>
       )
       break;
     default:

--- a/src/components/transcriptionRequest/TranscriptionRequestActivationWizard/TranscriptionRequestActivationWizard.js
+++ b/src/components/transcriptionRequest/TranscriptionRequestActivationWizard/TranscriptionRequestActivationWizard.js
@@ -1,0 +1,18 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+
+const TranscriptionRequestActivationWizard = props => {
+  const { transcriptionRequestId, isShowing } = props;
+  return (
+    <div className="transcriptionRequestActivationWizardWrapper">
+      the wizard ishere
+    </div>
+  );
+};
+
+TranscriptionRequestActivationWizard.propTypes = {
+  transcriptionRequestId: PropTypes.number,
+  isShowing: PropTypes.bool
+};
+
+export default TranscriptionRequestActivationWizard;

--- a/src/components/transcriptionRequest/TranscriptionRequestActivationWizard/TranscriptionRequestActivationWizard.js
+++ b/src/components/transcriptionRequest/TranscriptionRequestActivationWizard/TranscriptionRequestActivationWizard.js
@@ -1,7 +1,11 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState, useContext } from 'react';
 import PropTypes from 'prop-types';
 
+import { TranscriptionRequestContext } from '../TranscriptionRequestProvider';
+import { LanguageContext, LangugageContext } from '../../language/LanguageProvider';
 import TranscriptionRequestConfirm from './TranscriptionRequestConfirm/TranscriptionRequestConfirm';
+import transcriptionRequestConfirmFormConfig from './TranscriptionRequestConfirm/transcriptionRequestConfirmConfig';
+import { useFormConfig } from '../../form/formCustomHooks';
 
 const WIZARD_STATES = {
   0: TranscriptionRequestConfirm
@@ -10,7 +14,41 @@ const WIZARD_STATES = {
 const TranscriptionRequestActivationWizard = props => {
   const { transcriptionRequestId, isShowing } = props;
 
+  const { getTranscriptionRequestById } = useContext(TranscriptionRequestContext);
+  const { languages, getLanguages } = useContext(LanguageContext);
+
   const [ currentStep, setCurrentStep ] = useState(0);
+  const [ transcriptionRequestToConfirm, setTranscriptionRequestToConfirm ] = useState(null);
+  const [ transciptionRequestFormConfig, handleTranscriptionRequestChange, updateTranscriptionRequestFormConfig ] = useFormConfig(transcriptionRequestConfirmFormConfig);
+
+  useEffect(() => {
+    // react yells at you if your useEffect callback is async so it recommends you do this
+    const _getTranscriptionRequestById = async id => {
+      const _transcriptionRequestToConfirm = await getTranscriptionRequestById(id);
+      setTranscriptionRequestToConfirm(_transcriptionRequestToConfirm);
+    }
+
+    if(transcriptionRequestId) {
+      getLanguages();
+      _getTranscriptionRequestById(transcriptionRequestId);
+    }
+  }, [ transcriptionRequestId ]);
+
+  useEffect(() => {
+    if(languages.length && !transciptionRequestFormConfig.languageId.items.length) {
+      const items = languages.map(l => ({ value: l.id, displayName: l.name }));
+      updateTranscriptionRequestFormConfig('languageId', items, 'items');
+    }
+  }, [ languages, transciptionRequestFormConfig, updateTranscriptionRequestFormConfig ]);
+
+  useEffect(() => {
+    if(transcriptionRequestToConfirm) {
+      const { startTime, endTime } = transcriptionRequestToConfirm;
+
+      updateTranscriptionRequestFormConfig('startTime', startTime);
+      updateTranscriptionRequestFormConfig('endTime', endTime);
+    }
+  }, [ transcriptionRequestToConfirm ]);
 
   if(transcriptionRequestId === null) {
     return null;
@@ -18,7 +56,11 @@ const TranscriptionRequestActivationWizard = props => {
 
   return (
     <div className="transcriptionRequestActivationWizardWrapper">
-      the wizard ishere
+      {transcriptionRequestToConfirm && 
+        <TranscriptionRequestConfirm videoId={transcriptionRequestToConfirm.videoId}
+          formConfig={transciptionRequestFormConfig}
+          onChange={handleTranscriptionRequestChange} />
+      }
     </div>
   );
 };

--- a/src/components/transcriptionRequest/TranscriptionRequestActivationWizard/TranscriptionRequestActivationWizard.js
+++ b/src/components/transcriptionRequest/TranscriptionRequestActivationWizard/TranscriptionRequestActivationWizard.js
@@ -1,6 +1,12 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 
+import TranscriptionRequestConfirm from './TranscriptionRequestConfirm/TranscriptionRequestConfirm';
+
+const WIZARD_STATES = {
+  0: TranscriptionRequestConfirm
+};
+
 const TranscriptionRequestActivationWizard = props => {
   const { transcriptionRequestId, isShowing } = props;
 

--- a/src/components/transcriptionRequest/TranscriptionRequestActivationWizard/TranscriptionRequestActivationWizard.js
+++ b/src/components/transcriptionRequest/TranscriptionRequestActivationWizard/TranscriptionRequestActivationWizard.js
@@ -3,6 +3,13 @@ import PropTypes from 'prop-types';
 
 const TranscriptionRequestActivationWizard = props => {
   const { transcriptionRequestId, isShowing } = props;
+
+  const [ currentStep, setCurrentStep ] = useState(0);
+
+  if(transcriptionRequestId === null) {
+    return null;
+  }
+
   return (
     <div className="transcriptionRequestActivationWizardWrapper">
       the wizard ishere

--- a/src/components/transcriptionRequest/TranscriptionRequestActivationWizard/TranscriptionRequestActivationWizard.js
+++ b/src/components/transcriptionRequest/TranscriptionRequestActivationWizard/TranscriptionRequestActivationWizard.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import { TranscriptionRequestContext } from '../TranscriptionRequestProvider';
 import { LanguageContext } from '../../language/LanguageProvider';
 import TranscriptionRequestConfirm from './TranscriptionRequestConfirm/TranscriptionRequestConfirm';
-import transcriptionRequestConfirmFormConfig from './TranscriptionRequestConfirm/transcriptionRequestConfirmConfig';
+import initialTranscriptionRequestFormConfig from './TranscriptionRequestConfirm/transcriptionRequestConfirmConfig';
 import { useFormConfig, useIsFormValid } from '../../form/formCustomHooks';
 
 const WIZARD_STATES = {
@@ -15,12 +15,12 @@ const WIZARD_STATES = {
 const TranscriptionRequestActivationWizard = props => {
   const { transcriptionRequestId, isShowing } = props;
 
-  const { getTranscriptionRequestById } = useContext(TranscriptionRequestContext);
+  const { getTranscriptionRequestById, updateTranscriptionRequest } = useContext(TranscriptionRequestContext);
   const { languages, getLanguages } = useContext(LanguageContext);
 
   const [ currentStep, setCurrentStep ] = useState(0);
   const [ transcriptionRequestToConfirm, setTranscriptionRequestToConfirm ] = useState(null);
-  const [ transciptionRequestFormConfig, handleTranscriptionRequestChange, updateTranscriptionRequestFormConfig, resetTranscriptionRequestFormConfig ] = useFormConfig(transcriptionRequestConfirmFormConfig);
+  const [ transciptionRequestFormConfig, handleTranscriptionRequestChange, updateTranscriptionRequestFormConfig, resetTranscriptionRequestFormConfig ] = useFormConfig(initialTranscriptionRequestFormConfig);
   const isTranscriptionRequestFormValid = useIsFormValid(transciptionRequestFormConfig);
 
   useEffect(() => {
@@ -60,6 +60,17 @@ const TranscriptionRequestActivationWizard = props => {
     return null;
   }
 
+  const updateAndConfirmTranscriptionRequest = async () => {
+    const transcriptionRequestData = {
+      startTime: parseInt(transciptionRequestFormConfig.startTime.value),
+      endTime: parseInt(transciptionRequestFormConfig.endTime.value),
+      languageId: parseInt(transciptionRequestFormConfig.languageId.value)
+    };
+
+    await updateTranscriptionRequest(transcriptionRequestToConfirm.id, transcriptionRequestData);
+    setCurrentStep(currentStepVal => currentStepVal + 1);
+  };
+
   let transcriptionRequestActivationWizardBody;
   switch(currentStep) {
     case WIZARD_STATES.TRANSCRIPTION_REQUEST_CONFIRM:
@@ -68,7 +79,7 @@ const TranscriptionRequestActivationWizard = props => {
           formConfig={transciptionRequestFormConfig}
           onChange={handleTranscriptionRequestChange} />
         <div className="wizardActionsWrapper">
-          <button onClick={() => setCurrentStep(currentStep => currentStep + 1)} disabled={!isTranscriptionRequestFormValid}>Save and Confirm</button>
+          <button onClick={updateAndConfirmTranscriptionRequest} disabled={!isTranscriptionRequestFormValid}>Save and Confirm</button>
         </div>
       </>;
       break;

--- a/src/components/transcriptionRequest/TranscriptionRequestActivationWizard/TranscriptionRequestConfirm/TranscriptionRequestConfirm.js
+++ b/src/components/transcriptionRequest/TranscriptionRequestActivationWizard/TranscriptionRequestConfirm/TranscriptionRequestConfirm.js
@@ -1,0 +1,37 @@
+import React, { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+import YouTube from 'react-youtube';
+
+import Form from '../../../form/Form';
+
+const TranscriptionRequestConfirm = props => {
+  const { videoId, formConfig, onChange } = props;
+
+  const [ playerVars, setPlayerVars ] = useState({
+    start: props.formConfig.startTime.value,
+    end: props.formConfig.endTime.value
+  });
+
+  useEffect(() => {
+    const _playerVars = {
+      start: props.formConfig.startTime.value,
+      end: props.formConfig.endTime.value
+    };
+    setPlayerVars(_playerVars);
+  }, [ formConfig ]);
+
+  return (
+    <div className="transcriptionRequestConfirmWrapper">
+      <YouTube videoId={videoId} opts={{ playerVars }} />
+      <Form formConfig={formConfig} onChange={onChange} />
+    </div>
+  );
+};
+
+TranscriptionRequestConfirm.propTypes = {
+  videoId: PropTypes.string,
+  formConfig: PropTypes.object,
+  onChange: PropTypes.func
+};
+
+export default TranscriptionRequestConfirm;

--- a/src/components/transcriptionRequest/TranscriptionRequestActivationWizard/TranscriptionRequestConfirm/TranscriptionRequestConfirm.js
+++ b/src/components/transcriptionRequest/TranscriptionRequestActivationWizard/TranscriptionRequestConfirm/TranscriptionRequestConfirm.js
@@ -8,14 +8,14 @@ const TranscriptionRequestConfirm = props => {
   const { videoId, formConfig, onChange } = props;
 
   const [ playerVars, setPlayerVars ] = useState({
-    start: props.formConfig.startTime.value,
-    end: props.formConfig.endTime.value
+    start: formConfig.startTime.value,
+    end: formConfig.endTime.value
   });
 
   useEffect(() => {
     const _playerVars = {
-      start: props.formConfig.startTime.value,
-      end: props.formConfig.endTime.value
+      start: formConfig.startTime.value,
+      end: formConfig.endTime.value
     };
     setPlayerVars(_playerVars);
   }, [ formConfig ]);

--- a/src/components/transcriptionRequest/TranscriptionRequestActivationWizard/TranscriptionRequestConfirm/transcriptionRequestConfirmConfig.js
+++ b/src/components/transcriptionRequest/TranscriptionRequestActivationWizard/TranscriptionRequestConfirm/transcriptionRequestConfirmConfig.js
@@ -11,7 +11,7 @@ export default {
       isRequired: true
     },
     isTouched: false,
-    isValid: true
+    isValid: false
   },
 
   endTime: {
@@ -27,7 +27,7 @@ export default {
       mustBeGreaterThan: 'startTime'
     },
     isTouched: false,
-    isValid: true
+    isValid: false
   },
 
   languageId: {
@@ -42,6 +42,6 @@ export default {
       isRequired: true
     },
     isTouched: false,
-    isValid: true
+    isValid: false
   }
 };

--- a/src/components/transcriptionRequest/TranscriptionRequestActivationWizard/TranscriptionRequestConfirm/transcriptionRequestConfirmConfig.js
+++ b/src/components/transcriptionRequest/TranscriptionRequestActivationWizard/TranscriptionRequestConfirm/transcriptionRequestConfirmConfig.js
@@ -1,0 +1,47 @@
+export default {
+  startTime: {
+    inputType: 'input',
+    elementConfig: {
+      type: 'text',
+      name: 'startTime',
+      placeholder: 'Start Time'
+    },
+    value: '',
+    validation: {
+      isRequired: true
+    },
+    isTouched: false,
+    isValid: false
+  },
+
+  endTime: {
+    inputType: 'input',
+    elementConfig: {
+      type: 'text',
+      name: 'endTime',
+      placeholder: 'End Time'
+    },
+    value: '',
+    validation: {
+      isRequired: true,
+      mustBeGreaterThan: 'startTime'
+    },
+    isTouched: false,
+    isValid: false
+  },
+
+  languageId: {
+    inputType: 'select',
+    elementConfig: {
+      name: 'languageId',
+      placeholder: 'What Language Is This Segment In?'
+    },
+    value: '',
+    items: [],
+    validation: {
+      isRequired: true
+    },
+    isTouched: false,
+    isValid: false
+  }
+};

--- a/src/components/transcriptionRequest/TranscriptionRequestActivationWizard/TranscriptionRequestConfirm/transcriptionRequestConfirmConfig.js
+++ b/src/components/transcriptionRequest/TranscriptionRequestActivationWizard/TranscriptionRequestConfirm/transcriptionRequestConfirmConfig.js
@@ -11,7 +11,7 @@ export default {
       isRequired: true
     },
     isTouched: false,
-    isValid: false
+    isValid: true
   },
 
   endTime: {
@@ -27,7 +27,7 @@ export default {
       mustBeGreaterThan: 'startTime'
     },
     isTouched: false,
-    isValid: false
+    isValid: true
   },
 
   languageId: {
@@ -42,6 +42,6 @@ export default {
       isRequired: true
     },
     isTouched: false,
-    isValid: false
+    isValid: true
   }
 };

--- a/src/components/transcriptionRequest/TranscriptionRequestProvider.js
+++ b/src/components/transcriptionRequest/TranscriptionRequestProvider.js
@@ -31,9 +31,20 @@ export const TranscriptionRequestProvider = props => {
     await getTranscriptionRequests();
   };
 
+  const updateTranscriptionRequest = async (id, transcriptionRequestData) => {
+    await fetch(`http://localhost:8088/transcriptionRequests/${id}`, {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify(transcriptionRequestData)
+    });
+    await getTranscriptionRequests();
+  };
+
   return (
     <TranscriptionRequestContext.Provider value={{
-      transcriptionRequests, getTranscriptionRequests, saveTranscriptionRequest, getTranscriptionRequestById
+      transcriptionRequests, getTranscriptionRequests, saveTranscriptionRequest, getTranscriptionRequestById, updateTranscriptionRequest
     }}>{props.children}</TranscriptionRequestContext.Provider>
   );
 };

--- a/src/components/transcriptionRequest/TranscriptionRequestProvider.js
+++ b/src/components/transcriptionRequest/TranscriptionRequestProvider.js
@@ -11,6 +11,12 @@ export const TranscriptionRequestProvider = props => {
     setTranscriptionRequests(_transcriptionRequests);
   };
 
+  const getTranscriptionRequestById = async id => {
+    const res = await fetch(`http://localhost:8088/transcriptionRequests/${id}`);
+    const transcriptionRequest = await res.json();
+    return transcriptionRequest;
+  };
+
   const saveTranscriptionRequest = async transcriptionRequest => {
     transcriptionRequest.userId = parseInt(localStorage.getItem('current_user'));
     transcriptionRequest.isActivated = false;
@@ -27,7 +33,7 @@ export const TranscriptionRequestProvider = props => {
 
   return (
     <TranscriptionRequestContext.Provider value={{
-      transcriptionRequests, getTranscriptionRequests, saveTranscriptionRequest
+      transcriptionRequests, getTranscriptionRequests, saveTranscriptionRequest, getTranscriptionRequestById
     }}>{props.children}</TranscriptionRequestContext.Provider>
   );
 };

--- a/src/components/transcriptionRequestWorkshop/TranscriptionRequestWorkshop.js
+++ b/src/components/transcriptionRequestWorkshop/TranscriptionRequestWorkshop.js
@@ -5,12 +5,14 @@ import { TranscriptionRequestContext } from '../transcriptionRequest/Transcripti
 import YouTubeSearchBar from '../youTubeSearchBar/YouTubeSearchBar';
 import TranscriptionRequestControl from './TranscriptionRequestControl/TranscriptionRequestControl';
 import TranscriptionRequestList from '../transcriptionRequest/TranscriptionRequestList/TranscriptionRequestList';
+import TranscriptionRequestActivationWizard from '../transcriptionRequest/TranscriptionRequestActivationWizard/TranscriptionRequestActivationWizard';
 
 const TranscriptionRequestWorkshop = () => {
   const [ player, setPlayer ] = useState(null);
   const [ videoId, setVideoId ] = useState('');
   const [ startTime, setStartTime ] = useState(null);
   const [ transcriptionRequestsForVideo, setTranscriptionRequestsForVideo ] = useState([]);
+  const [ activatingTranscriptionRequestId, setActivatingTranscriptionRequestId ] = useState(null);
 
   const { transcriptionRequests, getTranscriptionRequests, saveTranscriptionRequest } = useContext(TranscriptionRequestContext);
 
@@ -53,9 +55,16 @@ const TranscriptionRequestWorkshop = () => {
       <YouTubeSearchBar value={videoId} onChange={handleYouTubeSearchBarChange} />
       <YouTube videoId={videoId} onReady={e => setPlayer(e.target)} />
 
-      <TranscriptionRequestControl isRequesting={!!startTime} onClick={handleTranscriptionRequestControlClick} />
+      <TranscriptionRequestControl isRequesting={startTime !== null} onClick={handleTranscriptionRequestControlClick} />
 
-      <TranscriptionRequestList transcriptionRequests={transcriptionRequestsForVideo} shouldHideVideoPreview={true} />
+      <TranscriptionRequestList 
+        onActivate={setActivatingTranscriptionRequestId}
+        transcriptionRequests={transcriptionRequestsForVideo} 
+        shouldHideVideoPreview={true} />
+
+      <TranscriptionRequestActivationWizard 
+        isShowing={activatingTranscriptionRequestId !== null}
+        transcriptionRequestId={activatingTranscriptionRequestId} />
     </section>
   );
 };


### PR DESCRIPTION
1. Verify that if you click "Activate Now" on a transcription request card, you will see the TranscriptionRequestActivationWizard component appear for that transcription request.
1. Verify that in this wizard component, it will initially render the TranscriptionRequestConfirm component, which is a component that renders a form allowing you to edit the transcription request that you created as, as well as showing you a preview of the YouTube player for the segment your transcription request covers.
1. Verify that if you change the start time or end time of a transcription request in this component, the YouTube player will automatically update to preview the segment that you have newly updated to.
1. Verify that the "Next" button in this component will not be enabled until the user has provided valid values for all of the inputs. If all are already present when initially loaded, the button should be enabled, and otherwise the button will be disabled at the start.
1. Verify that when you have changed values in the form and then click the Next button, the changes that you made will cause your transcription request to be updated in the DB via a PATCH.
1. Verify that if you make some changes in the wizard, then click Next, then click Back to go back to the TranscriptionRequestConfirm component, you will still be seeing the new values you supplied in your edit.