### PR TITLE
LoginAndRegister component now slides between login and registration forms on toggle.

### DIFF
--- a/src/components/auth/LoginAndRegister/LoginAndRegister.css
+++ b/src/components/auth/LoginAndRegister/LoginAndRegister.css
@@ -2,8 +2,37 @@
   border: 1px solid #0006;
   padding: 2rem;
   background-color: #ddd;
+  transition: all 1s;
+}
+
+.loginAndRegister.loginMode {
+  height: 315px;
+}
+
+.loginAndRegister.registerMode {
+  height: 575px;
 }
 
 .loginAndRegister__loginModeToggleButton {
   margin: 0 auto;
+}
+
+.loginFormWrapper,
+.registerFormWrapper {
+  transition: all 1s;
+}
+
+.loginFormWrapper.hidden,
+.registerFormWrapper.hidden {
+  opacity: 0;
+  visibility: hidden;
+  height: 0;
+}
+
+.loginFormWrapper.hidden {
+  transform: translateY(-200px);
+}
+
+.registerFormWrapper.hidden {
+  transform: translateY(400px);
 }

--- a/src/components/auth/LoginAndRegister/LoginAndRegister.css
+++ b/src/components/auth/LoginAndRegister/LoginAndRegister.css
@@ -3,7 +3,7 @@
   border: 1px solid #0006;
   padding: 2rem;
   background-color: #ddd;
-  transition: all 1s;
+  transition: height 1s;
 }
 
 .loginAndRegister.loginMode {
@@ -15,11 +15,10 @@
 }
 
 .loginAndRegister__loginModeToggleButton {
-  margin: 0 auto;
   position: absolute;
+  left: 50%;
   transform: translateX(-50%);
   transition: all 1s;
-  left: 50%;
 }
 
 .loginAndRegister.loginMode .loginAndRegister__loginModeToggleButton {
@@ -35,21 +34,21 @@
   transition: all 1s;
 }
 
-.registerFormWrapper {
+.loginAndRegister.registerMode .registerFormWrapper {
   margin-top: 60px;
 }
 
-.loginFormWrapper.hidden,
-.registerFormWrapper.hidden {
+.loginAndRegister.registerMode .loginFormWrapper,
+.loginAndRegister.loginMode .registerFormWrapper {
   opacity: 0;
   height: 0;
-  margin: 0;
+  visibility: hidden;
 }
 
-.loginFormWrapper.hidden {
+.loginAndRegister.registerMode .loginFormWrapper {
   transform: translateY(-200px);
 }
 
-.registerFormWrapper.hidden {
-  transform: translateY(400px);
+.loginAndRegister.loginMode .registerFormWrapper {
+  transform: translateY(200px);
 }

--- a/src/components/auth/LoginAndRegister/LoginAndRegister.css
+++ b/src/components/auth/LoginAndRegister/LoginAndRegister.css
@@ -1,4 +1,5 @@
 .loginAndRegister {
+  position: relative;
   border: 1px solid #0006;
   padding: 2rem;
   background-color: #ddd;
@@ -15,6 +16,18 @@
 
 .loginAndRegister__loginModeToggleButton {
   margin: 0 auto;
+  position: absolute;
+  transform: translateX(-50%);
+  transition: all 1s;
+  left: 50%;
+}
+
+.loginAndRegister.loginMode .loginAndRegister__loginModeToggleButton {
+  bottom: 2rem;
+}
+
+.loginAndRegister.registerMode .loginAndRegister__loginModeToggleButton {
+  bottom: 510px;
 }
 
 .loginFormWrapper,
@@ -22,11 +35,15 @@
   transition: all 1s;
 }
 
+.registerFormWrapper {
+  margin-top: 60px;
+}
+
 .loginFormWrapper.hidden,
 .registerFormWrapper.hidden {
   opacity: 0;
-  visibility: hidden;
   height: 0;
+  margin: 0;
 }
 
 .loginFormWrapper.hidden {

--- a/src/components/auth/LoginAndRegister/LoginAndRegister.js
+++ b/src/components/auth/LoginAndRegister/LoginAndRegister.js
@@ -8,12 +8,19 @@ const LoginAndRegister = props => {
   const [ isLoginMode, setIsLoginMode ] = useState(true);
 
   return (
-    <div className="loginAndRegister">
-      { isLoginMode && <LoginForm {...props} /> }
+    <div className={`loginAndRegister ${isLoginMode ? 'loginMode' : 'registerMode'}`}>
+      <div className={`loginFormWrapper ${isLoginMode ? '' : 'hidden'}`}>
+        <LoginForm {...props} />
+      </div>
+      {/* { isLoginMode && <LoginForm {...props} /> } */}
       <button className={`loginAndRegister__loginModeToggleButton btn ${isLoginMode ? 'btn--create' : 'btn--back'}`} onClick={() => setIsLoginMode(!isLoginMode)}>
         { isLoginMode ? 'Create Account' : 'Back to Login' }
       </button>
-      { !isLoginMode && <RegisterForm {...props} /> }
+      
+      <div className={`registerFormWrapper ${isLoginMode ? 'hidden' : ''}`}>
+        <RegisterForm {...props} />
+      </div>
+      {/* { !isLoginMode && <RegisterForm {...props} /> } */}
     </div>
   );
 };

--- a/src/components/auth/LoginAndRegister/LoginAndRegister.js
+++ b/src/components/auth/LoginAndRegister/LoginAndRegister.js
@@ -9,14 +9,15 @@ const LoginAndRegister = props => {
 
   return (
     <div className={`loginAndRegister ${isLoginMode ? 'loginMode' : 'registerMode'}`}>
-      <div className={`loginFormWrapper ${isLoginMode ? '' : 'hidden'}`}>
+      <div className="loginFormWrapper">
         <LoginForm {...props} />
       </div>
+
       <button className={`loginAndRegister__loginModeToggleButton btn ${isLoginMode ? 'btn--create' : 'btn--back'}`} onClick={() => setIsLoginMode(!isLoginMode)}>
         { isLoginMode ? 'Create Account' : 'Back to Login' }
       </button>
       
-      <div className={`registerFormWrapper ${isLoginMode ? 'hidden' : ''}`}>
+      <div className="registerFormWrapper">
         <RegisterForm {...props} />
       </div>
     </div>

--- a/src/components/auth/LoginAndRegister/LoginAndRegister.js
+++ b/src/components/auth/LoginAndRegister/LoginAndRegister.js
@@ -12,7 +12,6 @@ const LoginAndRegister = props => {
       <div className={`loginFormWrapper ${isLoginMode ? '' : 'hidden'}`}>
         <LoginForm {...props} />
       </div>
-      {/* { isLoginMode && <LoginForm {...props} /> } */}
       <button className={`loginAndRegister__loginModeToggleButton btn ${isLoginMode ? 'btn--create' : 'btn--back'}`} onClick={() => setIsLoginMode(!isLoginMode)}>
         { isLoginMode ? 'Create Account' : 'Back to Login' }
       </button>
@@ -20,7 +19,6 @@ const LoginAndRegister = props => {
       <div className={`registerFormWrapper ${isLoginMode ? 'hidden' : ''}`}>
         <RegisterForm {...props} />
       </div>
-      {/* { !isLoginMode && <RegisterForm {...props} /> } */}
     </div>
   );
 };


### PR DESCRIPTION
1. Verify that if you are looking at the login page, when you click "Create Account", the register form slides in from the bottom and the login form slides out of the top. And conversely, when you click "Back to Login", the login form slides in from the top, and the register form slides out from the bottom.