### PR TITLE
changing how i am positioning warning messages in login/register form cause of how strictly i am sizing stuff now hmm

### DIFF
--- a/src/components/auth/LoginForm/LoginForm.css
+++ b/src/components/auth/LoginForm/LoginForm.css
@@ -7,4 +7,9 @@
   width: 75%;
   margin: 0 auto;
   margin-bottom: 1rem;
+  position: absolute;
+  left: 50%;
+  top: 0;
+  transform: translate(-50%, -50%);
+  background-color: #000;
 }

--- a/src/components/auth/RegisterForm/RegisterForm.css
+++ b/src/components/auth/RegisterForm/RegisterForm.css
@@ -8,4 +8,9 @@
   text-align: center;
   width: 75%;
   margin: 1rem auto;
+  position: absolute;
+  left: 50%;
+  top: 55px;
+  transform: translateX(-50%);
+  background-color: #000
 }


### PR DESCRIPTION
1. Verify that if you provide invalid credentials on login, or if you attempt to register an account with an email that already has an account, the warning messages presented to you by the form are rendered in reasonable and non-interfering places.