### PR TITLE
Je prevent user from workshopping invalid start end segment

### DIFF
--- a/src/components/transcriptionRequestWorkshop/TranscriptionRequestControl/TranscriptionRequestControl.js
+++ b/src/components/transcriptionRequestWorkshop/TranscriptionRequestControl/TranscriptionRequestControl.js
@@ -2,10 +2,15 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const TranscriptionRequestControl = props => {
-  const { isRequesting, onClick } = props;
+  const { isRequesting, onClick, onCancel } = props;
 
   return (
     <div className="transcriptionRequestControlWrapper">
+      { isRequesting && 
+        <button className="transcriptionRequestCancel" onClick={onCancel}>
+          Cancel
+        </button>
+      }
       <button className="transcriptionRequestControl" onClick={onClick}>
         { isRequesting ? 'Stop Transcription Request' : 'Create Transcription Request' }
       </button>
@@ -15,7 +20,8 @@ const TranscriptionRequestControl = props => {
 
 TranscriptionRequestControl.propTypes = {
   isRequesting: PropTypes.bool,
-  onClick: PropTypes.func
+  onClick: PropTypes.func,
+  onCancel: PropTypes.func
 };
 
 export default TranscriptionRequestControl;

--- a/src/components/transcriptionRequestWorkshop/TranscriptionRequestWorkshop.js
+++ b/src/components/transcriptionRequestWorkshop/TranscriptionRequestWorkshop.js
@@ -44,11 +44,12 @@ const TranscriptionRequestWorkshop = () => {
 
   const handleTranscriptionRequestControlClick = async () => {
     const timeClicked = player.getCurrentTime();
+    const roundedTime = startTime === null ? Math.floor(timeClicked) : Math.ceil(timeClicked);
 
     if(startTime === null) {
-      setStartTime(Math.floor(timeClicked));
+      setStartTime(roundedTime);
     }
-    else if(Math.ceil(timeClicked) <= startTime) {
+    else if(roundedTime <= startTime) {
       setHasEndTimeError(true);
     }
     else {
@@ -57,7 +58,7 @@ const TranscriptionRequestWorkshop = () => {
       const transcriptionRequestData = {
         videoId,
         startTime: startTime,
-        endTime: Math.ceil(timeClicked)
+        endTime: roundedTime
       };
 
       await saveTranscriptionRequest(transcriptionRequestData);


### PR DESCRIPTION
1. Verify that you can no longer specify an end time that is equal to or less than the start time you set on a video in the workshop (e.g., play a video, click the create transcription request button, rewind the video to a point before the start time you chose, and then if you click end transcription request button you will see an error rendered above the control and you will not be allowed to specify that end time).
1. Verify that the cancel button that appears while creating a transcription request will take you out of request mode.