### PR TITLE
<TimeInput> element and paired validation checks.

### DIFF
--- a/src/components/form/Form.js
+++ b/src/components/form/Form.js
@@ -27,6 +27,8 @@ const Form = props => {
 
   const handleChange = e => {
     const isValid = validate(e.target.name, e.target.value);
+    console.log('form change', e.target.name, e.target.value);
+    console.log(isValid);
     onChange({
       name: e.target.name,
       value: e.target.value,
@@ -50,9 +52,9 @@ const Form = props => {
       if(parseFloat(value) >= parseFloat(formConfig[validation.mustBeLessThan].value)) return false;
     }
 
-    if(validation.mustBeGreaterThan) {
-      if(parseFloat(value) <= parseFloat(formConfig[validation.mustBeGreaterThan].value)) return false;
-    }
+    // if(validation.mustBeGreaterThan) {
+      // if(parseFloat(value) <= parseFloat(formConfig[validation.mustBeGreaterThan].value)) return false;
+    // }
     
     return true;
   };

--- a/src/components/form/Form.js
+++ b/src/components/form/Form.js
@@ -27,8 +27,6 @@ const Form = props => {
 
   const handleChange = e => {
     const isValid = validate(e.target.name, e.target.value);
-    console.log('form change', e.target.name, e.target.value);
-    console.log(isValid);
     onChange({
       name: e.target.name,
       value: e.target.value,
@@ -49,12 +47,12 @@ const Form = props => {
     }
 
     if(validation.mustBeLessThan) {
-      if(parseFloat(value) >= parseFloat(formConfig[validation.mustBeLessThan].value)) return false;
+      if(isNaN(value) || isNaN(formConfig[validation.mustBeLessThan].value) || parseFloat(value) >= parseFloat(formConfig[validation.mustBeLessThan].value)) return false;
     }
 
-    // if(validation.mustBeGreaterThan) {
-      // if(parseFloat(value) <= parseFloat(formConfig[validation.mustBeGreaterThan].value)) return false;
-    // }
+    if(validation.mustBeGreaterThan) {
+      if(isNaN(value) || isNaN(formConfig[validation.mustBeGreaterThan].value) || parseFloat(value) <= parseFloat(formConfig[validation.mustBeGreaterThan].value)) return false;
+    }
     
     return true;
   };

--- a/src/components/form/formCustomHooks.js
+++ b/src/components/form/formCustomHooks.js
@@ -29,6 +29,7 @@ export const useFormConfig = initialFormConfig => {
     const pairedElement = formConfig[name].validation.mustBeLessThan || formConfig[name].validation.mustBeGreaterThan || formConfig[name].validation.mustMatch;
     if(pairedElement) {
       updateFormConfig(pairedElement, isValid, 'isValid');
+      updateFormConfig(pairedElement, isTouched, 'isTouched');
     }
   };
 

--- a/src/components/form/formCustomHooks.js
+++ b/src/components/form/formCustomHooks.js
@@ -21,16 +21,15 @@ export const useFormConfig = initialFormConfig => {
   const handleChange = changeData => {
     const { name, value, isValid, isTouched } = changeData;
 
-    const updatedFormConfig = { ...formConfig };
-    const updatedFormElement = { 
-      ...updatedFormConfig[name], 
-      value,
-      isValid,
-      isTouched
-    };
-    updatedFormConfig[name] = updatedFormElement;
+    updateFormConfig(name, value, 'value');
+    updateFormConfig(name, isValid, 'isValid');
+    updateFormConfig(name, isTouched, 'isTouched');
 
-    setFormConfig(updatedFormConfig);
+    // update validation for a "paired" field as well, if the field being updated currently is part of a pair wherein the validity of one of the pair implies the validity of the other
+    const pairedElement = formConfig[name].validation.mustBeLessThan || formConfig[name].validation.mustBeGreaterThan || formConfig[name].validation.mustMatch;
+    if(pairedElement) {
+      updateFormConfig(pairedElement, isValid, 'isValid');
+    }
   };
 
   const updateFormConfig = (formFieldName, newValue, propertyToUpdate = 'value') => {

--- a/src/components/form/input/Input.js
+++ b/src/components/form/input/Input.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 
 import Select from '../select/Select';
 import './Input.css';
+import TimeInput from '../timeInput/TimeInput';
 
 const Input = props => {
   const { inputType, isTouched, isValid, label, elementConfig, value, onChange, items } = props;
@@ -28,6 +29,12 @@ const Input = props => {
         onChange={onChange}
         className={className}
         items={items} />;
+      break;
+    case 'time':
+      inputElement = <TimeInput {...elementConfig}
+        value={value}
+        onChange={onChange}
+        className={className} />;
       break;
     default:
       throw new Error('You must provide a valid inputType.');

--- a/src/components/form/timeInput/TimeInput.js
+++ b/src/components/form/timeInput/TimeInput.js
@@ -1,12 +1,13 @@
 import React from 'react';
 
-import { convertTimeStringToSeconds, convertSecondsToTimeString } from '../../../utils/timeFormatters';
+import { formatToMSSTimeString, convertTimeStringToSeconds, convertSecondsToTimeString } from '../../../utils/timeFormatters';
 
 const TimeInput = props => {
   const { onChange, value } = props;
 
   const handleChange = e => {
-    e.target.value = convertTimeStringToSeconds(e.target.value);
+    const timeString = formatToMSSTimeString(e.target.value);
+    e.target.value = convertTimeStringToSeconds(timeString);
     onChange(e);
   };
 

--- a/src/components/form/timeInput/TimeInput.js
+++ b/src/components/form/timeInput/TimeInput.js
@@ -1,40 +1,9 @@
 import React from 'react';
 
+import { convertTimeStringToSeconds, convertSecondsToTimeString } from '../../../utils/timeFormatters';
+
 const TimeInput = props => {
   const { onChange, value } = props;
-
-  const convertSecondsToTimeString = seconds => {
-    if(seconds.toString().includes(':')) return seconds;
-    seconds = parseInt(seconds);
-    if(!seconds) return '0:00';
-
-    const minutesPart = Math.floor(seconds / 60);
-    let secondsPart = seconds % 60;
-    if(secondsPart.toString().length === 1) secondsPart = '0' + secondsPart;
-
-    return `${minutesPart}:${secondsPart}`;
-  };
-
-  const convertTimeStringToSeconds = timeString => {
-    const timeStringParts = timeString.split(':');
-    while(timeStringParts.length < 2) {
-      timeStringParts.unshift('0');
-    }
-
-    if(timeStringParts[1].length > 2) {
-      timeStringParts[0] += timeStringParts[1].substring(0, timeStringParts[1].length - 2);
-      if(parseInt(timeStringParts[0]) === 0) timeStringParts[0] = '0';
-      timeStringParts[1] = timeStringParts[1].substring(timeStringParts[1].length - 2);
-    }
-    else if(timeStringParts[1].length === 1 && timeStringParts[0]) {
-      timeStringParts[1] = timeStringParts[0].charAt(timeStringParts[0].length - 1) + timeStringParts[1];
-      timeStringParts[0] = timeStringParts[0].substring(0, timeStringParts[0].length - 1) || '0';
-    }
-
-    if(parseInt(timeStringParts[1]) >= 60) return timeStringParts.join(':');
-
-    return (60 * (parseInt(timeStringParts[0]) || 0)) + parseInt(timeStringParts[1]);
-  };
 
   const handleChange = e => {
     e.target.value = convertTimeStringToSeconds(e.target.value);

--- a/src/components/form/timeInput/TimeInput.js
+++ b/src/components/form/timeInput/TimeInput.js
@@ -37,7 +37,6 @@ const TimeInput = props => {
 
   const handleChange = e => {
     e.target.value = convertTimeStringToSeconds(e.target.value);
-    console.log(e.target.value);
     onChange(e);
   };
 

--- a/src/components/form/timeInput/TimeInput.js
+++ b/src/components/form/timeInput/TimeInput.js
@@ -23,11 +23,12 @@ const TimeInput = props => {
 
     if(timeStringParts[1].length > 2) {
       timeStringParts[0] += timeStringParts[1].substring(0, timeStringParts[1].length - 2);
+      if(parseInt(timeStringParts[0]) === 0) timeStringParts[0] = '0';
       timeStringParts[1] = timeStringParts[1].substring(timeStringParts[1].length - 2);
     }
     else if(timeStringParts[1].length === 1 && timeStringParts[0]) {
       timeStringParts[1] = timeStringParts[0].charAt(timeStringParts[0].length - 1) + timeStringParts[1];
-      timeStringParts[0] = timeStringParts[0].substring(0, timeStringParts[0].length - 1);
+      timeStringParts[0] = timeStringParts[0].substring(0, timeStringParts[0].length - 1) || '0';
     }
 
     if(parseInt(timeStringParts[1]) >= 60) return timeStringParts.join(':');

--- a/src/components/form/timeInput/TimeInput.js
+++ b/src/components/form/timeInput/TimeInput.js
@@ -1,0 +1,52 @@
+import React from 'react';
+
+const TimeInput = props => {
+  const { onChange, value } = props;
+
+  const convertSecondsToTimeString = seconds => {
+    if(seconds.toString().includes(':')) return seconds;
+    seconds = parseInt(seconds);
+    if(!seconds) return '0:00';
+
+    const minutesPart = Math.floor(seconds / 60);
+    let secondsPart = seconds % 60;
+    if(secondsPart.toString().length === 1) secondsPart = '0' + secondsPart;
+
+    return `${minutesPart}:${secondsPart}`;
+  };
+
+  const convertTimeStringToSeconds = timeString => {
+    const timeStringParts = timeString.split(':');
+    while(timeStringParts.length < 2) {
+      timeStringParts.unshift('0');
+    }
+
+    if(timeStringParts[1].length > 2) {
+      timeStringParts[0] += timeStringParts[1].substring(0, timeStringParts[1].length - 2);
+      timeStringParts[1] = timeStringParts[1].substring(timeStringParts[1].length - 2);
+    }
+    else if(timeStringParts[1].length === 1 && timeStringParts[0]) {
+      timeStringParts[1] = timeStringParts[0].charAt(timeStringParts[0].length - 1) + timeStringParts[1];
+      timeStringParts[0] = timeStringParts[0].substring(0, timeStringParts[0].length - 1);
+    }
+
+    if(parseInt(timeStringParts[1]) >= 60) return timeStringParts.join(':');
+
+    return (60 * (parseInt(timeStringParts[0]) || 0)) + parseInt(timeStringParts[1]);
+  };
+
+  const handleChange = e => {
+    e.target.value = convertTimeStringToSeconds(e.target.value);
+    console.log(e.target.value);
+    onChange(e);
+  };
+
+  return (
+    <input {...props}
+      type="text"
+      value={convertSecondsToTimeString(value)}
+      onChange={handleChange} />
+  );
+};
+
+export default TimeInput;

--- a/src/components/transcriptionRequest/TranscriptionRequestActivationWizard/TranscriptionRequestConfirm/transcriptionRequestConfirmConfig.js
+++ b/src/components/transcriptionRequest/TranscriptionRequestActivationWizard/TranscriptionRequestConfirm/transcriptionRequestConfirmConfig.js
@@ -10,6 +10,7 @@ export default {
     value: '',
     validation: {
       isRequired: true,
+      mustBeNumeric: true,
       mustBeLessThan: 'endTime'
     },
     isTouched: false,
@@ -27,6 +28,7 @@ export default {
     value: '',
     validation: {
       isRequired: true,
+      mustBeNumeric: true,
       mustBeGreaterThan: 'startTime'
     },
     isTouched: false,

--- a/src/components/transcriptionRequest/TranscriptionRequestActivationWizard/TranscriptionRequestConfirm/transcriptionRequestConfirmConfig.js
+++ b/src/components/transcriptionRequest/TranscriptionRequestActivationWizard/TranscriptionRequestConfirm/transcriptionRequestConfirmConfig.js
@@ -1,6 +1,6 @@
 export default {
   startTime: {
-    inputType: 'input',
+    inputType: 'time',
     label: 'Start Time',
     elementConfig: {
       type: 'text',
@@ -17,7 +17,7 @@ export default {
   },
 
   endTime: {
-    inputType: 'input',
+    inputType: 'time',
     label: 'End Time',
     elementConfig: {
       type: 'text',

--- a/src/components/transcriptionRequest/TranscriptionRequestCard/TranscriptionRequestCard.js
+++ b/src/components/transcriptionRequest/TranscriptionRequestCard/TranscriptionRequestCard.js
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import YouTube from 'react-youtube';
 
+import { convertSecondsToTimeString } from '../../../utils/timeFormatters';
 import './TranscriptionRequestCard.css';
 
 const TranscriptionRequestCard = props => {
@@ -38,8 +39,8 @@ const TranscriptionRequestCard = props => {
         </div>
       }
       <div className="transcriptionRequest__timeInformationWrapper">
-        <p className="transcriptionRequest__startTime">Start Time: {transcriptionRequest.startTime}</p>
-        <p className="transcriptionRequest__endTime">End Time: {transcriptionRequest.endTime}</p>
+        <p className="transcriptionRequest__startTime">Start Time: {convertSecondsToTimeString(transcriptionRequest.startTime)}</p>
+        <p className="transcriptionRequest__endTime">End Time: {convertSecondsToTimeString(transcriptionRequest.endTime)}</p>
       </div>
       <div className="transcriptionRequest__actionWrapper">
         { transcriptionRequestActionContent }

--- a/src/utils/timeFormatters.js
+++ b/src/utils/timeFormatters.js
@@ -1,5 +1,9 @@
+/**
+ * Given an amount of seconds, convert into string in M:SS format. If provided seconds value is not numeric, will just return the provided value back.
+ * @param {any} seconds Amount of seconds to turn into M:SS formatted string. If isNaN, just returns seconds as passed in.
+ */
 export const convertSecondsToTimeString = seconds => {
-  if(seconds.toString().includes(':')) return seconds;
+  if(isNaN(seconds)) return seconds;
   seconds = parseInt(seconds);
   if(!seconds) return '0:00';
 
@@ -10,7 +14,12 @@ export const convertSecondsToTimeString = seconds => {
   return `${minutesPart}:${secondsPart}`;
 };
 
-export const convertTimeStringToSeconds = timeString => {
+/**
+ * Given a time string, format it so that it will always be in the M:SS format. Does not care about if the returned time string represents a valid time, just that it is formatted to M:SS. If a string is supplied with more than two digits on the right side of a colon delimiter, will remove leading digits from right side of delimiter value until it is two digits in length, and will append the removed digits to the end of the value on the first side of the delimiter.
+ * Examples: '' -> 0:00, '3:32' -> '3:32', ':52' -> '0:52', '3:324' -> '33:24'
+ * @param {String} timeString A time string, possibly invalidly formatted, to format into M:SS.
+ */
+export const formatToMSSTimeString = timeString => {
   const timeStringParts = timeString.split(':');
   while(timeStringParts.length < 2) {
     timeStringParts.unshift('0');
@@ -26,7 +35,17 @@ export const convertTimeStringToSeconds = timeString => {
     timeStringParts[0] = timeStringParts[0].substring(0, timeStringParts[0].length - 1) || '0';
   }
 
-  if(parseInt(timeStringParts[1]) >= 60) return timeStringParts.join(':');
+  return timeStringParts.join(':');
+};
+
+/**
+ * Given a time string of the format M:SS, convert to amount of seconds. If time string refers to an invalid time (e.g., seconds value >= 60) just return the time string as passed-in.
+ * @param {String} timeString Time string of the format M:SS
+ */
+export const convertTimeStringToSeconds = timeString => {
+  const timeStringParts = timeString.split(':');
+
+  if(parseInt(timeStringParts[1]) >= 60) return timeString;
 
   return (60 * (parseInt(timeStringParts[0]) || 0)) + parseInt(timeStringParts[1]);
 };

--- a/src/utils/timeFormatters.js
+++ b/src/utils/timeFormatters.js
@@ -1,0 +1,32 @@
+export const convertSecondsToTimeString = seconds => {
+  if(seconds.toString().includes(':')) return seconds;
+  seconds = parseInt(seconds);
+  if(!seconds) return '0:00';
+
+  const minutesPart = Math.floor(seconds / 60);
+  let secondsPart = seconds % 60;
+  if(secondsPart.toString().length === 1) secondsPart = '0' + secondsPart;
+
+  return `${minutesPart}:${secondsPart}`;
+};
+
+export const convertTimeStringToSeconds = timeString => {
+  const timeStringParts = timeString.split(':');
+  while(timeStringParts.length < 2) {
+    timeStringParts.unshift('0');
+  }
+
+  if(timeStringParts[1].length > 2) {
+    timeStringParts[0] += timeStringParts[1].substring(0, timeStringParts[1].length - 2);
+    if(parseInt(timeStringParts[0]) === 0) timeStringParts[0] = '0';
+    timeStringParts[1] = timeStringParts[1].substring(timeStringParts[1].length - 2);
+  }
+  else if(timeStringParts[1].length === 1 && timeStringParts[0]) {
+    timeStringParts[1] = timeStringParts[0].charAt(timeStringParts[0].length - 1) + timeStringParts[1];
+    timeStringParts[0] = timeStringParts[0].substring(0, timeStringParts[0].length - 1) || '0';
+  }
+
+  if(parseInt(timeStringParts[1]) >= 60) return timeStringParts.join(':');
+
+  return (60 * (parseInt(timeStringParts[0]) || 0)) + parseInt(timeStringParts[1]);
+};


### PR DESCRIPTION
1. Verify that the inputs for selecting the start and end point of your video in the TranscriptionRequestConfirm form of the wizard are now "time" inputs. These inputs expect the user to input a string in the format of M:SS, but the underlying value reported on change events is the amount of seconds that the user's time string translates to, if the time string is valid.
1. Verify that everything still works as before, but now the user can input a more sensible start time and end time for the video.
1. Verify that if you provide an invalid value in either the startTime or the endTime inputs, that BOTH inputs will have red borders indicating invalidity. 
1. Verify that if you fix the invalid value from either the startTime or the endTime, that BOTH inputs will no longer have red borders indicating invalidity.