### PR TITLE
better invalid password/custom password feedback in the register form

### DIFF
--- a/src/components/auth/RegisterForm/RegisterForm.css
+++ b/src/components/auth/RegisterForm/RegisterForm.css
@@ -14,3 +14,8 @@
   transform: translateX(-50%);
   background-color: #000
 }
+
+.registerForm input[name="password"].invalid {
+  outline: none;
+  border: none;
+}

--- a/src/components/auth/RegisterForm/registerFormConfig.js
+++ b/src/components/auth/RegisterForm/registerFormConfig.js
@@ -53,7 +53,9 @@ export default {
     },
     value: '',
     validation: {
-      isRequired: true
+      isRequired: true,
+      mustMatch: 'confirmPassword',
+      doesNotCausePairedTouch: true
     },
     isTouched: false,
     isValid: false

--- a/src/components/form/formCustomHooks.js
+++ b/src/components/form/formCustomHooks.js
@@ -29,7 +29,9 @@ export const useFormConfig = initialFormConfig => {
     const pairedElement = formConfig[name].validation.mustBeLessThan || formConfig[name].validation.mustBeGreaterThan || formConfig[name].validation.mustMatch;
     if(pairedElement) {
       updateFormConfig(pairedElement, isValid, 'isValid');
-      updateFormConfig(pairedElement, isTouched, 'isTouched');
+      if(!formConfig[name].validation.doesNotCausePairedTouch) {
+        updateFormConfig(pairedElement, isTouched, 'isTouched');
+      }
     }
   };
 


### PR DESCRIPTION
Verify that the register form has now been implemented such that:
1. No invalid warning styling will ever show on the "Password" field
1. An invalid warning styling will only ever show on the "Confirm Password" field
1. An invalid warning styling will only ever be showing on the "Confirm Password" field if the user has typed something into that field, and whatever they typed does not match the value in the "password" field
1. The invalid warning styling will disappear if the values in password and confirm password fields become the same by any way (e.g., changing the confirm value to match the password value, or changing the password value to match the confirm value).