### PR TITLE
Only show replay button after initial play, derender wizard body when not visible

### DIFF
--- a/src/components/transcriptionRequest/TranscriptionRequestActivationWizard/TranscriptionRequestActivationWizard.js
+++ b/src/components/transcriptionRequest/TranscriptionRequestActivationWizard/TranscriptionRequestActivationWizard.js
@@ -30,6 +30,7 @@ const TranscriptionRequestActivationWizard = props => {
   const [ currentStep, setCurrentStep ] = useState(WIZARD_STATES.TRANSCRIPTION_REQUEST_CONFIRM);
   const [ transcriptionRequestToConfirm, setTranscriptionRequestToConfirm ] = useState(null);
   const [ transcriptionRequestToFulfill, setTranscriptionRequestToFulfill ] = useState(null);
+  const [ shouldRenderBody, setShouldRenderBody ] = useState(false);
 
   const [ transciptionRequestFormConfig, handleTranscriptionRequestChange, updateTranscriptionRequestFormConfig, resetTranscriptionRequestFormConfig ] = useFormConfig(initialTranscriptionRequestFormConfig);
   const isTranscriptionRequestFormValid = useIsFormValid(transciptionRequestFormConfig);
@@ -51,6 +52,7 @@ const TranscriptionRequestActivationWizard = props => {
     }
 
     if(transcriptionRequestId) {
+      setShouldRenderBody(true);
       resetTranscriptionRequestFormConfig();
       resetTranscriptionFormConfig();
       setCurrentStep(WIZARD_STATES.TRANSCRIPTION_REQUEST_CONFIRM);
@@ -58,6 +60,10 @@ const TranscriptionRequestActivationWizard = props => {
       getLanguages();
       _getTranscriptionRequestById(transcriptionRequestId);
       _getTranscriptionRequestToFulfill();
+    }
+    else {
+      const timeoutId = setTimeout(() => setShouldRenderBody(false), 1000);
+      return () => clearTimeout(timeoutId);
     }
   }, [ transcriptionRequestId ]);
 
@@ -150,7 +156,7 @@ const TranscriptionRequestActivationWizard = props => {
               defaultMessage="Activate Transcription Request" />
           </h2>
         </div>
-        { transcriptionRequestActivationWizardBody }
+        { shouldRenderBody && transcriptionRequestActivationWizardBody }
       </div>
     </Modal>
   );

--- a/src/components/transcriptionRequest/TranscriptionRequestActivationWizard/TranscriptionRequestActivationWizard.js
+++ b/src/components/transcriptionRequest/TranscriptionRequestActivationWizard/TranscriptionRequestActivationWizard.js
@@ -30,7 +30,6 @@ const TranscriptionRequestActivationWizard = props => {
   const [ currentStep, setCurrentStep ] = useState(WIZARD_STATES.TRANSCRIPTION_REQUEST_CONFIRM);
   const [ transcriptionRequestToConfirm, setTranscriptionRequestToConfirm ] = useState(null);
   const [ transcriptionRequestToFulfill, setTranscriptionRequestToFulfill ] = useState(null);
-  const [ shouldRenderBody, setShouldRenderBody ] = useState(false);
 
   const [ transciptionRequestFormConfig, handleTranscriptionRequestChange, updateTranscriptionRequestFormConfig, resetTranscriptionRequestFormConfig ] = useFormConfig(initialTranscriptionRequestFormConfig);
   const isTranscriptionRequestFormValid = useIsFormValid(transciptionRequestFormConfig);
@@ -51,8 +50,8 @@ const TranscriptionRequestActivationWizard = props => {
       setTranscriptionRequestToFulfill(_transcriptionRequestToFulfill);
     }
 
+    // if a new transcription request id is coming in via props, reinitialize the form config states, perform the various async calls needed for the wizard to run, and set the current step to the first wizard step
     if(transcriptionRequestId) {
-      setShouldRenderBody(true);
       resetTranscriptionRequestFormConfig();
       resetTranscriptionFormConfig();
       setCurrentStep(WIZARD_STATES.TRANSCRIPTION_REQUEST_CONFIRM);
@@ -61,8 +60,10 @@ const TranscriptionRequestActivationWizard = props => {
       _getTranscriptionRequestById(transcriptionRequestId);
       _getTranscriptionRequestToFulfill();
     }
+
+    // otherwise if the transcription request id coming in is not an id (e.g., null), set wizard state to null to indicate not active
     else {
-      const timeoutId = setTimeout(() => setShouldRenderBody(false), 1000);
+      const timeoutId = setTimeout(() => setCurrentStep(null), 1000);
       return () => clearTimeout(timeoutId);
     }
   }, [ transcriptionRequestId ]);
@@ -144,7 +145,7 @@ const TranscriptionRequestActivationWizard = props => {
       </>;
       break;
     default:
-      throw new Error('Invalid state in TranscriptionRequestActivationWizard');
+      transcriptionRequestActivationWizardBody = null;
   }
 
   return (
@@ -156,7 +157,7 @@ const TranscriptionRequestActivationWizard = props => {
               defaultMessage="Activate Transcription Request" />
           </h2>
         </div>
-        { shouldRenderBody && transcriptionRequestActivationWizardBody }
+        { transcriptionRequestActivationWizardBody }
       </div>
     </Modal>
   );

--- a/src/components/youtube/YouTubePlayer/YouTubePlayer.css
+++ b/src/components/youtube/YouTubePlayer/YouTubePlayer.css
@@ -7,4 +7,12 @@
 
 .youTubePlayer__restart {
   margin: 0.5rem 0;
+  transition: all 1s;
+  padding: 1rem;
+  opacity: 1;
+}
+
+.youTubePlayer__restart.hidden {
+  padding: 0;
+  opacity: 0;
 }

--- a/src/components/youtube/YouTubePlayer/YouTubePlayer.js
+++ b/src/components/youtube/YouTubePlayer/YouTubePlayer.js
@@ -10,6 +10,7 @@ const YouTubePlayer = props => {
 
   const [ isRefreshing, setIsRefreshing ] = useState(false);
   const [ isAutoplay, setIsAutoplay ] = useState(false);
+  const [ hasPlayed, setHasPlayed ] = useState(false);
 
   const expandedOpts = { ...opts };
   if(!expandedOpts.playerVars) expandedOpts.playerVars = {};
@@ -28,13 +29,22 @@ const YouTubePlayer = props => {
     }
   }, [ isRefreshing ]);
 
+  const handleStateChange = e => {
+    if(e.data === YouTube.PlayerState.PLAYING) {
+      setHasPlayed(true);
+    }
+    if(props.onStateChange) {
+      props.onStateChange(e);
+    }
+  };
+
   return (
     <div className="youTubePlayerWrapper">
       <div style={{ height: opts.height + 'px', width: opts.width + 'px' }}>
-        { !isRefreshing && <YouTube {...props} opts={expandedOpts} /> }
+        { !isRefreshing && <YouTube {...props} opts={expandedOpts} onStateChange={handleStateChange} /> }
       </div>
       { showResetButton && 
-        <button className="btn btn--action youTubePlayer__restart" onClick={() => setIsRefreshing(true)}>
+        <button className={`btn btn--action youTubePlayer__restart ${hasPlayed ? '' : 'hidden'}`} onClick={() => setIsRefreshing(true)}>
           <FormattedMessage id="youTubePlayer.replayButton"
             defaultMessage="Replay Segment" />
         </button>


### PR DESCRIPTION
1. Verify that the YouTube players in the wizard will not render the replay segment button until the user actually starts playing the segment for the first time.
1. Verify that the wizard body is also derendered when the wizard is not active, fixing a bug where if you were playing a YouTube video in the wizard, then closed the modal while the video was still playing, it would just keep playing offscreen.