### PR TITLE
fixing bug, deleting all text in timeInput should render as 0:00 not NaN

### DIFF
--- a/src/utils/timeFormatters.js
+++ b/src/utils/timeFormatters.js
@@ -20,6 +20,8 @@ export const convertSecondsToTimeString = seconds => {
  * @param {String} timeString A time string, possibly invalidly formatted, to format into M:SS.
  */
 export const formatToMSSTimeString = timeString => {
+  if(!timeString) return '0:00';
+
   const timeStringParts = timeString.split(':');
   while(timeStringParts.length < 2) {
     timeStringParts.unshift('0');
@@ -34,6 +36,8 @@ export const formatToMSSTimeString = timeString => {
     timeStringParts[1] = timeStringParts[0].charAt(timeStringParts[0].length - 1) + timeStringParts[1];
     timeStringParts[0] = timeStringParts[0].substring(0, timeStringParts[0].length - 1) || '0';
   }
+
+  debugger;
 
   return timeStringParts.join(':');
 };


### PR DESCRIPTION
1. Verify that if you Cmd+A then Delete one of the TimeInput fields in the wizard, that you see 0:00 rendered in that input, not NaN.