### PR TITLE
end time is styled as red in recording preview if invalid (<= starttime)

### DIFF
--- a/src/components/transcriptionRequestWorkshop/TranscriptionRequestRecordingPreview/TranscriptionRequestRecordingPreview.css
+++ b/src/components/transcriptionRequestWorkshop/TranscriptionRequestRecordingPreview/TranscriptionRequestRecordingPreview.css
@@ -13,3 +13,7 @@
   font-weight: bold;
   font-size: 1.2rem;
 }
+
+.transcriptionRequestRecordingPreview__timeValue.invalid {
+  color: #f00;
+}

--- a/src/components/transcriptionRequestWorkshop/TranscriptionRequestRecordingPreview/TranscriptionRequestRecordingPreview.js
+++ b/src/components/transcriptionRequestWorkshop/TranscriptionRequestRecordingPreview/TranscriptionRequestRecordingPreview.js
@@ -22,7 +22,7 @@ const TranscriptionRequestRecordingPreview = props => {
       </p>
       <p className="transcriptionRequestRecordingPreview__endTime">
         <FormattedMessage id="transcriptionRequestRecordingPreview.currentEndTimeLabel"
-          defaultMessage="End Time" />: <span className="transcriptionRequestRecordingPreview__timeValue">{convertSecondsToTimeString(endTime)}</span>
+          defaultMessage="End Time" />: <span className={`transcriptionRequestRecordingPreview__timeValue ${endTime <= startTime ? 'invalid' : ''}`}>{convertSecondsToTimeString(endTime)}</span>
       </p>
     </div>
   </>;


### PR DESCRIPTION
1. Verify that if you are in the process of requesting a transcription in the workshop, if you rewind the video such that the end time is <= the start time, the end time in the recording preview is displayed in red to indicate invalidity.