### PR TITLE
Moving out API target URL to a shared context of all providers

### DIFF
--- a/src/ApiProvider.js
+++ b/src/ApiProvider.js
@@ -1,0 +1,11 @@
+import React, { createContext } from 'react';
+
+const API_URL = 'http://localhost:8088';
+
+export const ApiContext = createContext();
+
+export const ApiProvider = props => (
+  <ApiContext.Provider value={API_URL}>
+    {props.children}
+  </ApiContext.Provider>
+);

--- a/src/components/language/LanguageProvider.js
+++ b/src/components/language/LanguageProvider.js
@@ -1,12 +1,16 @@
-import React, { createContext, useState } from 'react';
+import React, { createContext, useContext, useState } from 'react';
+
+import { ApiContext } from '../../ApiProvider';
 
 export const LanguageContext = createContext();
 
 export const LanguageProvider = props => {
   const [ languages, setLanguages ] = useState([]);
+
+  const API_URL = useContext(ApiContext);
   
   const getLanguages = async () => {
-    const res = await fetch('http://localhost:8088/languages');
+    const res = await fetch(`${API_URL}/languages`);
     const _languages = await res.json();
     setLanguages(_languages);
   };

--- a/src/components/transcription/TranscriptionProvider.js
+++ b/src/components/transcription/TranscriptionProvider.js
@@ -1,18 +1,22 @@
-import React, { createContext, useState } from 'react';
+import React, { createContext, useContext, useState } from 'react';
+
+import { ApiContext } from '../../ApiProvider';
 
 export const TranscriptionContext = createContext();
 
 export const TranscriptionProvider = props => {
   const [ transcriptions, setTranscriptions ] = useState([]);
 
+  const API_URL = useContext(ApiContext);
+
   const getTranscriptions = async () => {
-    const res = await fetch(`http://localhost:8088/transcriptions?_expand=transcriptionRequest`);
+    const res = await fetch(`${API_URL}/transcriptions?_expand=transcriptionRequest`);
     const _transcriptions = await res.json();
     setTranscriptions(_transcriptions);
   };
 
   const getTranscriptionById = async id => {
-    const res = await fetch(`http://localhost:8088/transcriptions/${id}?_expand=transcriptionRequest&_expand=user`);
+    const res = await fetch(`${API_URL}/transcriptions/${id}?_expand=transcriptionRequest&_expand=user`);
     const transcription = await res.json();
     return transcription;
   };
@@ -22,7 +26,7 @@ export const TranscriptionProvider = props => {
     transcriptionData.isAccepted = false;
     transcriptionData.userId = parseInt(localStorage.getItem('current_user'));
 
-    const res = await fetch('http://localhost:8088/transcriptions', {
+    const res = await fetch(`${API_URL}/transcriptions`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json'
@@ -35,7 +39,7 @@ export const TranscriptionProvider = props => {
   };
 
   const acceptTranscription = async id => {
-    await fetch(`http://localhost:8088/transcriptions/${id}`, {
+    await fetch(`${API_URL}/transcriptions/${id}`, {
       method: 'PATCH',
       headers: {
         'Content-Type': 'application/json'
@@ -47,7 +51,7 @@ export const TranscriptionProvider = props => {
   };
 
   const deleteTranscription = async id => {
-    await fetch(`http://localhost:8088/transcriptions/${id}`, {
+    await fetch(`${API_URL}/transcriptions/${id}`, {
       method: 'DELETE'
     });
     return await getTranscriptions();

--- a/src/components/transcriptionRequest/TranscriptionRequestProvider.js
+++ b/src/components/transcriptionRequest/TranscriptionRequestProvider.js
@@ -1,24 +1,28 @@
-import React, { useState, createContext } from 'react';
+import React, { useState, useContext, createContext } from 'react';
+
+import { ApiContext } from '../../ApiProvider';
 
 export const TranscriptionRequestContext = createContext();
 
 export const TranscriptionRequestProvider = props => {
   const [ transcriptionRequests, setTranscriptionRequests ] = useState([]);
 
+  const API_URL = useContext(ApiContext);
+
   const getTranscriptionRequests = async () => {
-    const res = await fetch('http://localhost:8088/transcriptionRequests?_embed=transcriptions');
+    const res = await fetch(`${API_URL}/transcriptionRequests?_embed=transcriptions`);
     const _transcriptionRequests = await res.json();
     setTranscriptionRequests(_transcriptionRequests);
   };
 
   const getTranscriptionRequestById = async id => {
-    const res = await fetch(`http://localhost:8088/transcriptionRequests/${id}`);
+    const res = await fetch(`${API_URL}/transcriptionRequests/${id}`);
     const transcriptionRequest = await res.json();
     return transcriptionRequest;
   };
 
   const getTranscriptionRequestToFulfillForLanguage = async languageId => {
-    const res = await fetch(`http://localhost:8088/transcriptionRequests?_embed=transcriptions&languageId=${languageId}&userId_ne=${localStorage.getItem('current_user')}&_sort=timestamp&isActivated=true`);
+    const res = await fetch(`${API_URL}/transcriptionRequests?_embed=transcriptions&languageId=${languageId}&userId_ne=${localStorage.getItem('current_user')}&_sort=timestamp&isActivated=true`);
     const candidates = await res.json();
     return candidates.find(tR => tR.transcriptions.length === 0) || false;
   };
@@ -27,7 +31,7 @@ export const TranscriptionRequestProvider = props => {
     transcriptionRequest.userId = parseInt(localStorage.getItem('current_user'));
     transcriptionRequest.isActivated = false;
 
-    await fetch('http://localhost:8088/transcriptionRequests', {
+    await fetch(`${API_URL}/transcriptionRequests`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json'
@@ -38,7 +42,7 @@ export const TranscriptionRequestProvider = props => {
   };
 
   const updateTranscriptionRequest = async (id, transcriptionRequestData) => {
-    await fetch(`http://localhost:8088/transcriptionRequests/${id}`, {
+    await fetch(`${API_URL}/transcriptionRequests/${id}`, {
       method: 'PATCH',
       headers: {
         'Content-Type': 'application/json'
@@ -58,7 +62,7 @@ export const TranscriptionRequestProvider = props => {
   };
 
   const deleteTranscriptionRequest = async id => {
-    await fetch(`http://localhost:8088/transcriptionRequests/${id}`, {
+    await fetch(`${API_URL}/transcriptionRequests/${id}`, {
       method: 'DELETE'
     });
     await getTranscriptionRequests();

--- a/src/components/user/UserProvider.js
+++ b/src/components/user/UserProvider.js
@@ -1,30 +1,34 @@
-import React, { createContext, useState } from 'react';
+import React, { createContext, useContext, useState } from 'react';
+
+import { ApiContext } from '../../ApiProvider';
 
 export const UserContext = createContext();
 
 export const UserProvider = props => {
   const [ users, setUsers ] = useState([]);
 
+  const API_URL = useContext(ApiContext);
+
   const getUsers = async () => {
-    const res = await fetch('http://localhost:8088/users');
+    const res = await fetch(`${API_URL}/users`);
     const _users = await res.json();
     setUsers(_users);
   };
 
   const getUserByEmail = async email => {
-    const res = await fetch(`http://localhost:8088/users?email=${email}`);
+    const res = await fetch(`${API_URL}/users?email=${email}`);
     const _users = await res.json();
     return _users.length ? _users[0] : false;
   };
 
   const getUserById = async id => {
-    const res = await fetch(`http://localhost:8088/users/${id}`);
+    const res = await fetch(`${API_URL}/users/${id}`);
     const user = await res.json();
     return user;
   };
 
   const saveUser = async userData => {
-    const res = await fetch('http://localhost:8088/users', {
+    const res = await fetch(`${API_URL}/users`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json'

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ import { BrowserRouter } from 'react-router-dom';
 import { IntlProvider } from 'react-intl';
 
 import UhhhWut from './components/UhhhWut';
+import { ApiProvider } from './ApiProvider';
 import localeData from './locales.json';
 import './index.css';
 
@@ -26,7 +27,9 @@ ReactDOM.render(
   <React.StrictMode>
     <BrowserRouter>
       <IntlProvider locale={language} messages={messages}>
-        <UhhhWut />
+        <ApiProvider>
+          <UhhhWut />
+        </ApiProvider>
       </IntlProvider>
     </BrowserRouter>
   </React.StrictMode>,


### PR DESCRIPTION
Now the API_URL is set in the ApiContext. So if you move the API to another URL from `http://localhost:8088` you only have to change the value in that context for everything to work.