### PR TITLE
escape to leave modal

### DIFF
--- a/src/components/modal/Modal.js
+++ b/src/components/modal/Modal.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import Backdrop from './Backdrop/Backdrop';
 
@@ -6,6 +6,20 @@ import './Modal.css';
 
 const Modal = props => {
   const { isShowing, onClose } = props;
+
+  const handleEscape = e => {
+    if(e.key === 'Escape') {
+      onClose();
+    }
+  };
+
+  useEffect(() => {
+    if(isShowing) {
+      document.addEventListener('keydown', handleEscape);
+
+      return () => document.removeEventListener('keydown', handleEscape);
+    }
+  }, [ isShowing ]);
 
   return <>
     <Backdrop isShowing={isShowing} onClick={onClose} />


### PR DESCRIPTION
You can now input the escape key to leave the modal, in addition to clicking on the backdrop.