### PR TITLE
Je fix welcome banner animation tab away bug

### DIFF
--- a/src/components/unauthorizedUserLandingPage/WelcomeBanner/WelcomeBanner.js
+++ b/src/components/unauthorizedUserLandingPage/WelcomeBanner/WelcomeBanner.js
@@ -52,7 +52,7 @@ const WelcomeBanner = () => {
       welcomeHeader.current.style.opacity = 1;
     };
 
-    const animationCallback = timestamp => {
+    const animationCallback = () => {
       if(!start) start = Date.now();
       const elapsed = Date.now() - start;
 

--- a/src/components/unauthorizedUserLandingPage/WelcomeBanner/WelcomeBanner.js
+++ b/src/components/unauthorizedUserLandingPage/WelcomeBanner/WelcomeBanner.js
@@ -49,11 +49,13 @@ const WelcomeBanner = () => {
     const restartAnimationCycle = () => {
       start = null;
       hasResetWelcomeMessage = false;
+      welcomeHeader.current.style.opacity = 1;
     };
 
     const animationCallback = timestamp => {
-      if(!start) start = timestamp;
-      const elapsed = timestamp - start;
+      if(!start) start = Date.now();
+      const elapsed = Date.now() - start;
+      console.log(elapsed);
 
       // if the current point in the animation cycle indicates we should be either fading out or back in, update the opacity of the welcome banner header 
       if(elapsed >= FADE_OUT_POINT && elapsed <= ANIMATION_DURATION) {

--- a/src/components/unauthorizedUserLandingPage/WelcomeBanner/WelcomeBanner.js
+++ b/src/components/unauthorizedUserLandingPage/WelcomeBanner/WelcomeBanner.js
@@ -55,7 +55,6 @@ const WelcomeBanner = () => {
     const animationCallback = timestamp => {
       if(!start) start = Date.now();
       const elapsed = Date.now() - start;
-      console.log(elapsed);
 
       // if the current point in the animation cycle indicates we should be either fading out or back in, update the opacity of the welcome banner header 
       if(elapsed >= FADE_OUT_POINT && elapsed <= ANIMATION_DURATION) {


### PR DESCRIPTION
Closes #26 

Verify that if you tab away while the welcome banner on the landing page is in the process of animating, that when you jump back to the page several seconds later, the animation is in a predictable state (fully opaque, will be at the start of its animation cycle).