### PR TITLE
Je handle shortened links

### DIFF
--- a/src/components/youtube/YouTubeSearchBar/YouTubeSearchBar.js
+++ b/src/components/youtube/YouTubeSearchBar/YouTubeSearchBar.js
@@ -14,10 +14,26 @@ defineMessages({
 const YouTubeSearchBar = props => {
   const { value, onChange } = props;
 
+  const getVideoIdFromYouTubeURL = youTubeUrl => {
+    if(youTubeUrl.searchParams.has('v')) {
+      return youTubeUrl.searchParams.get('v');
+    }
+    else {
+      return youTubeUrl.pathname.substring(1);
+    }
+  };
+
   const handleChange = e => {
     try {
-      const youtubeURL = new URL(e.target.value);
-      onChange(youtubeURL.searchParams.get('v'));
+      const url = new URL(e.target.value);
+
+      if(url.hostname === 'youtube.com' || url.hostname === 'www.youtube.com' || url.hostname === 'youtu.be') {
+        const videoId = getVideoIdFromYouTubeURL(url);
+        onChange(videoId);
+      }
+      else {
+        onChange(e.target.value);
+      }
     }
     catch {
       onChange(e.target.value);

--- a/src/components/youtube/YouTubeSearchBar/YouTubeSearchBar.js
+++ b/src/components/youtube/YouTubeSearchBar/YouTubeSearchBar.js
@@ -15,15 +15,21 @@ const YouTubeSearchBar = props => {
   const { value, onChange } = props;
 
   const getVideoIdFromYouTubeURL = youTubeUrl => {
+
+    // url of the form www.youtube.com/watch?v=VIDEO_ID
     if(youTubeUrl.searchParams.has('v')) {
       return youTubeUrl.searchParams.get('v');
     }
+
+    // shortened url of the form youtu.be/VIDEO_ID
     else {
       return youTubeUrl.pathname.substring(1);
     }
   };
 
   const handleChange = e => {
+
+    // try to parse the input as a URL
     try {
       const url = new URL(e.target.value);
 
@@ -35,6 +41,8 @@ const YouTubeSearchBar = props => {
         onChange(e.target.value);
       }
     }
+
+    // URL constructor throws an error if supplied string is not a valid URL - just send up the user input in this case
     catch {
       onChange(e.target.value);
     }


### PR DESCRIPTION
Closes #67 

Verify that you can now paste a YouTube URL of the form `youtu.be/VIDEO_ID` in addition to the other formats that always worked.